### PR TITLE
Handle unspecific errors in response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 composer.lock
+.idea

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -69,8 +69,8 @@ class Response
         $responseBody = json_decode($response->getBody()->getContents(), true);
 
         if (isset($responseBody['status']) && !in_array(Str::lower($responseBody['status']), static::$validStatuses)) {
-            $errorCode = $responseBody['statusCode'];
-            $message = $responseBody['statusDetail'];
+            $errorCode = intval($responseBody['statusCode'] ?? 1017);
+            $message = $responseBody['statusDetail'] ?? 'The transaction was declined';
 
             throw new SagePayException($errorCode, $message, $response->getStatusCode());
         }


### PR DESCRIPTION
When a transaction is declined by the bank the error is not always a sage pay error code. Produce a default response in this case.

Replicated on test sage pay using the test cards detailed here: https://test.sagepay.com/documentation/#test-card-details