### PR TITLE
Store responses and handle declined by bank response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 composer.lock
+.idea

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -29,6 +29,11 @@ class Response
     ];
 
     /**
+     * @var array
+     */
+    protected static $responses = [];
+
+    /**
      * @param Exception $exception
      * @throws SagePayException
      */
@@ -68,6 +73,8 @@ class Response
     {
         $responseBody = json_decode($response->getBody()->getContents(), true);
 
+        static::$responses[] = $responseBody;
+
         if (isset($responseBody['status']) && !in_array(Str::lower($responseBody['status']), static::$validStatuses)) {
             $errorCode = intval($responseBody['statusCode'] ?? 1017);
             $message = $responseBody['statusDetail'] ?? 'The transaction was declined';
@@ -76,5 +83,13 @@ class Response
         }
 
         return $responseBody;
+    }
+
+    /**
+     * @return array
+     */
+    public static function responses(): array
+    {
+        return static::$responses;
     }
 }

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -69,8 +69,8 @@ class Response
         $responseBody = json_decode($response->getBody()->getContents(), true);
 
         if (isset($responseBody['status']) && !in_array(Str::lower($responseBody['status']), static::$validStatuses)) {
-            $errorCode = $responseBody['statusCode'];
-            $message = $responseBody['statusDetail'];
+            $errorCode = intval($responseBody['statusCode'] ?? 1017);
+            $message = $responseBody['statusDetail'] ?? 'The transaction was declined';
 
             throw new SagePayException($errorCode, $message, $response->getStatusCode());
         }

--- a/src/SagePay.php
+++ b/src/SagePay.php
@@ -2,16 +2,17 @@
 
 namespace Oilstone\SagePay;
 
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Oilstone\SagePay\Contracts\TransactionType;
 use Oilstone\SagePay\DataTypes\Transaction;
 use Oilstone\SagePay\Exceptions\SagePayException;
+use Oilstone\SagePay\Http\Response;
 use Oilstone\SagePay\Registries\Config;
 use Oilstone\SagePay\TransactionTypes\Authorisation;
 use Oilstone\SagePay\TransactionTypes\Payment;
 use Oilstone\SagePay\TransactionTypes\Refund;
 use Oilstone\SagePay\TransactionTypes\Repeat;
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Collection;
 
 /**
  * Class SagePay
@@ -108,5 +109,13 @@ class SagePay
     public function batches(Carbon $startDate, Carbon $endDate): Collection
     {
         return (new Reports())->batchList($startDate, $endDate);
+    }
+
+    /**
+     * @return Collection
+     */
+    public function responses(): Collection
+    {
+        return collect(Response::responses());
     }
 }


### PR DESCRIPTION
- Store responses received from Sage Pay
- Add new `responses()` method to retrieve stored responses
- Fix declined by bank response handling